### PR TITLE
Complete refactor of endpoint detection logic

### DIFF
--- a/lib/client/client.ts
+++ b/lib/client/client.ts
@@ -7,6 +7,7 @@ import {
   AwsServiceError, ServiceError,
   Credentials, CredentialsProvider,
   getRequestId,
+  EndpointResolver,
 } from './common.ts';
 
 import { readXmlResult, stringify } from "../encoding/xml.ts";
@@ -21,15 +22,14 @@ type SigningFetcher = (request: Request, opts: FetchOpts) => Promise<Response>;
 
 export class BaseApiFactory implements ApiFactory {
   #credentials: CredentialsProvider;
+  #endpointResolver: EndpointResolver;
   #region?: string;
-  #fixedEndpoint?: string;
-  #baseDomain?: string;
   constructor(opts: {
     credentialProvider?: CredentialsProvider,
     credentials?: Credentials,
+    endpointResolver: EndpointResolver,
     region?: string;
     fixedEndpoint?: string;
-    baseDomain?: string;
   }) {
     if (opts.credentials != null) {
       const {credentials} = opts;
@@ -45,13 +45,7 @@ export class BaseApiFactory implements ApiFactory {
       if (err.name !== 'PermissionDenied') throw err;
     }
 
-    if (typeof opts.fixedEndpoint == 'string') {
-      if (!opts.fixedEndpoint.includes('://')) throw new Error(
-        `If provided, fixedEndpoint must be a full URL including https:// or http://`);
-      this.#fixedEndpoint = opts.fixedEndpoint;
-    } else if (typeof opts.baseDomain == 'string') {
-      this.#baseDomain = opts.baseDomain;
-    }
+    this.#endpointResolver = opts.endpointResolver;
   }
 
   makeNew<T>(apiConstructor: ServiceApiClass<T>): T {
@@ -60,51 +54,22 @@ export class BaseApiFactory implements ApiFactory {
 
   // TODO: second argument for extra config (endpoint, logging, etc)
   buildServiceClient(apiMetadata: ApiMetadata): ServiceClient {
-    if (apiMetadata.signatureVersion === 'v2') {
-      throw new Error(`TODO: signature version ${apiMetadata.signatureVersion}`);
-    }
-
-    const globalEndpointPrefix = apiMetadata
-      .globalEndpoint?.replace(/\.amazonaws\.com$/, '');
-
-    // Try dual-stacking sometimes
-    const endpointPrefix =
-      apiMetadata.serviceId === 'S3' ? 's3.dualstack' :
-      apiMetadata.endpointPrefix;
+    if (apiMetadata.signatureVersion === 'v2') throw new Error(
+      `TODO: signature version ${apiMetadata.signatureVersion}`);
 
     const signingFetcher: SigningFetcher = async (request: Request, opts: FetchOpts): Promise<Response> => {
-      // QUIRK: try using host routing for S3 buckets when helpful
-      // TODO: this isn't actually signing relevant!
-      // we just have better info here...
-      if (apiMetadata.serviceId === 'S3' && opts.urlPath && !opts.hostPrefix && !this.#fixedEndpoint) {
-        const [bucketName] = opts.urlPath.slice(1).split(/[?/]/);
-        if (bucketName.length > 0 && !bucketName.includes('.')) {
-          opts.hostPrefix = `${bucketName}.`;
-          const path = opts.urlPath.slice(bucketName.length+1);
-          opts.urlPath = path.startsWith('/') ? path : `/${path}`;
-        }
-      }
 
       if (opts.skipSigning) {
         // Try to find the region without trying too hard (defaulting is ok in case of global endpoints)
         const region = opts.region ?? this.#region
           ?? (await this.#credentials.getCredentials().then(x => x.region, () => undefined));
-        const baseDomain = this.#baseDomain ?? getRootDomain(apiMetadata.serviceId, region);
 
-        const endpoint = this.#fixedEndpoint ??
-          `https://${opts.hostPrefix ?? ''}${baseDomain === 'aws' ? 'api.' : ''}${
-            globalEndpointPrefix || `${endpointPrefix}.${region ?? throwMissingRegion()}`
-          }.${baseDomain}`;
-
-        // work around deno 1.9 request cloning regression :(
-        return fetch(new URL(opts.urlPath, endpoint).toString(), {
-          headers: request.headers,
-          method: request.method,
-          body: request.body,
-          redirect: request.redirect,
-          // TODO: request cancellation
-          // signal: request.signal,
-        });
+        return fetch(this.#endpointResolver.resolveUrl({
+          apiMetadata: apiMetadata,
+          region: region ?? 'us-east-1',
+          requestPath: opts.urlPath,
+          hostPrefix: opts.hostPrefix,
+        }).url, request);
       }
 
       // Resolve credentials and AWS region
@@ -113,26 +78,17 @@ export class BaseApiFactory implements ApiFactory {
         ?? (apiMetadata.globalEndpoint ? 'us-east-1'
         : (this.#region ?? credentials.region ?? throwMissingRegion()));
 
-      const baseDomain = this.#baseDomain ?? getRootDomain(apiMetadata.serviceId, region);
+      const {url, signingRegion} = this.#endpointResolver.resolveUrl({
+        apiMetadata: apiMetadata,
+        region: region,
+        requestPath: opts.urlPath,
+        hostPrefix: opts.hostPrefix,
+      });
 
-      // TODO: service URL can vary for lots of reasons:
-      // - dualstack/IPv6 on alt hostnames for EC2 (some regions) and S3 (all regions?)
-      // - govcloud, aws-cn, etc
-      //   ^ this should be auto detected from region now
-      // - localstack, minio etc - completely custom
-      //   ^ this should be supported now via `fixedEndpoint`
-
-      const signer = new AWSSignerV4(region, credentials);
+      const signer = new AWSSignerV4(signingRegion ?? region, credentials);
       const signingName = apiMetadata.signingName ?? apiMetadata.endpointPrefix;
 
-      // Assemble full URL
-      const endpoint = this.#fixedEndpoint ||
-        `https://${opts.hostPrefix ?? ''}${baseDomain === 'aws' ? 'api.' : ''}${
-          globalEndpointPrefix || `${endpointPrefix}.${region}`
-        }.${baseDomain}`;
-      const fullUrl = new URL(opts.urlPath, endpoint).toString();
-
-      const req = await signer.sign(signingName, fullUrl, request);
+      const req = await signer.sign(signingName, url, request);
       // console.log(req.method, url);
       return fetch(req);
     }
@@ -418,25 +374,4 @@ async function handleErrorResponse(response: Response, reqMethod: string): Promi
     console.log('Error body:', await response.text());
   }
   throw new Error(`Unrecognizable error response of type ${contentType}`);
-}
-
-// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/Using_Endpoints.html
-const dualStackEc2Regions = new Set([
-  'us-east-1',
-  'us-east-2',
-  'us-west-2',
-  'eu-west-1',
-  'ap-south-1',
-  'sa-east-1',
-]);
-
-function getRootDomain(serviceId: string, region = 'us-east-1') {
-  // partially dual-stacked APIs on new TLD
-  if (serviceId === 'EC2' && dualStackEc2Regions.has(region)) return 'aws';
-  // non-default partitions
-  if (region.startsWith('cn-')) return 'amazonaws.com.cn';
-  if (region.startsWith('us-iso-')) return 'c2s.ic.gov';
-  if (region.startsWith('us-isob-')) return 'sc2s.sgov.gov';
-  // old faithful
-  return 'amazonaws.com';
 }

--- a/lib/client/common.ts
+++ b/lib/client/common.ts
@@ -12,7 +12,21 @@ export interface CredentialsProvider {
 
 /** Generic AWS Signer interface */
 export interface Signer {
-  sign: (service: string, url: string, request: Request) => Promise<Request>;
+  sign: (service: string, url: URL, request: Request) => Promise<Request>;
+}
+
+export interface EndpointParameters {
+  apiMetadata: ApiMetadata;
+  region: string;
+  hostPrefix?: string;
+  requestPath: string;
+}
+export interface ResolvedEndpoint {
+  url: URL;
+  signingRegion?: string;
+}
+export interface EndpointResolver {
+  resolveUrl: (parameters: EndpointParameters) => ResolvedEndpoint;
 }
 
 // The HTTP contract expected by all service API implementations

--- a/lib/client/credentials.ts
+++ b/lib/client/credentials.ts
@@ -205,8 +205,11 @@ export class TokenFileWebIdentityCredentials implements CredentialsProvider {
     if (!this.#roleArn) throw new Error(`No Role ARN is set`);
 
     const client = new BaseApiFactory({
-      // TODO: give a region here when AWS_STS_REGIONAL_ENDPOINTS is present
+      // TODO: give a region here when AWS_STS_REGIONAL_ENDPOINTS=regional
       // https://github.com/cloudydeno/deno-aws_api/issues/2
+      endpointResolver: new AwsEndpointResolver({
+        forceRegional: false, // TODO as above
+      }),
       credentialProvider: { getCredentials: () => Promise.reject(new Error(
         `No credentials necesary to AssumeRoleWithWebIdentity`)) },
     }).buildServiceClient(StsApiMetadata);
@@ -321,6 +324,7 @@ export function getDefaultRegion(): string {
 
 import type { ServiceClient, ApiMetadata } from "./common.ts";
 import { readXmlResult, XmlNode } from "../encoding/xml.ts";
+import { AwsEndpointResolver } from "./endpoints.ts";
 
 const StsApiMetadata: ApiMetadata = {
   apiVersion: "2011-06-15",

--- a/lib/client/endpoints.ts
+++ b/lib/client/endpoints.ts
@@ -1,0 +1,135 @@
+import type {
+  EndpointParameters,
+  EndpointResolver,
+  ResolvedEndpoint,
+} from "./common.ts";
+export type {
+  EndpointParameters,
+  EndpointResolver,
+} from "./common.ts";
+
+export class AwsEndpointResolver implements EndpointResolver {
+  constructor({
+    useDualstack = true,
+    forceRegional = false,
+  } = {}) {
+    this.useDualstack = useDualstack;
+    this.forceRegional = forceRegional;
+  }
+  useDualstack: boolean;
+  forceRegional: boolean;
+
+  resolveUrl(parameters: EndpointParameters): ResolvedEndpoint {
+    const { serviceId, globalEndpoint } = parameters.apiMetadata;
+    let serviceLabel = parameters.apiMetadata.endpointPrefix;
+    let signingRegion = parameters.region;
+
+    // S3: Dualstack, and/or Host-Style Routing
+    if (serviceId === 'S3') {
+      if (this.useDualstack) serviceLabel += '.dualstack';
+      perhapsUpgradeEndpointParametersToHostStyleRouting(parameters);
+    }
+
+    // Select AWS partition (GovCloud, etc)
+    let rootDomain = getRootDomain(parameters.region);
+
+    // Use the global endpoint if present and not disallowed
+    if (globalEndpoint && !this.forceRegional) {
+      // Global endpoints always sign as us-east-1
+      signingRegion = 'us-east-1';
+      // Still need to follow AWS partition
+      serviceLabel = globalEndpoint.replace(/\.amazonaws\.com$/, '');
+    } else {
+      // Add region after the service token
+      serviceLabel = `${serviceLabel}.${parameters.region}`;
+    }
+
+    // EC2: Dualstack is on a totally different TLD and only some regions
+    if (serviceId === 'EC2' && this.useDualstack &&
+        dualStackEc2Regions.has(parameters.region)) {
+      parameters.hostPrefix = `${parameters.hostPrefix ?? ''}api.`;
+      rootDomain = '.aws';
+    }
+
+    // Build final URL
+    const urlPrefix = `https://${parameters.hostPrefix ?? ''}`;
+    const fullUrl = `${urlPrefix}${serviceLabel}${rootDomain}`;
+    return {
+      url: new URL(parameters.requestPath, fullUrl),
+      signingRegion,
+    };
+  }
+}
+
+function getRootDomain(region: string) {
+  // non-default partitions
+  if (region.startsWith('cn-')) return '.amazonaws.com.cn';
+  if (region.startsWith('us-iso-')) return '.c2s.ic.gov';
+  if (region.startsWith('us-isob-')) return '.sc2s.sgov.gov';
+  // old faithful
+  return '.amazonaws.com';
+}
+
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/Using_Endpoints.html
+const dualStackEc2Regions = new Set([
+  'us-east-1',
+  'us-east-2',
+  'us-west-2',
+  'eu-west-1',
+  'ap-south-1',
+  'sa-east-1',
+]);
+
+
+// Intended for regional providers of just S3 APIs
+// Example: [example-bucket.]us-east-1.linodeobjects.com
+export class S3CompatibleEndpointResolver implements EndpointResolver {
+  constructor(
+    public readonly baseDomain: string,
+  ) {
+    if (this.baseDomain.includes('/')) throw new Error(
+      `Fixed domain must be a naked domain name, without protocol or path`);
+  }
+  resolveUrl(parameters: EndpointParameters): ResolvedEndpoint {
+    if (parameters.apiMetadata.serviceId !== 'S3') throw new Error(
+      `${this.constructor.name} only implements S3 requests`);
+
+    perhapsUpgradeEndpointParametersToHostStyleRouting(parameters);
+
+    const endpoint = `https://${parameters.hostPrefix ?? ''}${parameters.region}.${this.baseDomain}`;
+    return { url: new URL(parameters.requestPath, endpoint) };
+  }
+}
+// export const LinodeObjectsEndpointResolver
+//   = new S3CompatibleEndpointResolver('linodeobjects.com');
+
+
+export class FixedBaseEndpointResolver implements EndpointResolver {
+  constructor(
+    public readonly baseUrl: string,
+  ) {
+    if (!this.baseUrl.includes('://')) throw new Error(
+      `Fixed endpoint must be a full URL including https:// or http://`);
+  }
+  resolveUrl(parameters: EndpointParameters): ResolvedEndpoint {
+    return { url: new URL(parameters.requestPath, this.baseUrl) };
+  }
+}
+
+
+/**
+ * Possibly mutates an EndpointParameters to S3's host-based routing.
+ * Effectively, if at least one path element is found,
+ * it can beshifted out of the path and into the "hostPrefix" field.
+ * Values containing a dot are currently skipped because of TLS complications.
+ */
+function perhapsUpgradeEndpointParametersToHostStyleRouting(parameters: EndpointParameters) {
+  if (!parameters.requestPath || parameters.hostPrefix) return;
+
+  const [bucketName] = parameters.requestPath.slice(1).split(/[?/]/);
+  if (bucketName.length > 0 && !bucketName.includes('.')) {
+    parameters.hostPrefix = `${bucketName}.`;
+    const path = parameters.requestPath.slice(bucketName.length+1);
+    parameters.requestPath = path.startsWith('/') ? path : `/${path}`;
+  }
+}

--- a/lib/client/endpoints_test.ts
+++ b/lib/client/endpoints_test.ts
@@ -1,0 +1,219 @@
+import { assertEquals, assertThrows } from "https://deno.land/std@0.105.0/testing/asserts.ts";
+import type { ApiMetadata } from "./common.ts";
+import { AwsEndpointResolver, FixedBaseEndpointResolver, S3CompatibleEndpointResolver } from "./endpoints.ts";
+
+Deno.test('aws ec2 / use aws china partition', async () => {
+  const resolver = new AwsEndpointResolver();
+
+  assertEquals(resolver.resolveUrl({
+    requestPath: '/path',
+    region: 'cn-none-1',
+    apiMetadata: apiMetadata.ec2,
+  }).url.toString(), 'https://ec2.cn-none-1.amazonaws.com.cn/path');
+});
+
+Deno.test('aws ec2 / use aws iso partition', async () => {
+  const resolver = new AwsEndpointResolver();
+
+  assertEquals(resolver.resolveUrl({
+    requestPath: '/path',
+    region: 'us-iso-none-1',
+    apiMetadata: apiMetadata.ec2,
+  }).url.toString(), 'https://ec2.us-iso-none-1.c2s.ic.gov/path');
+});
+
+Deno.test('aws ec2 / opportunistic dualstack', async () => {
+  const resolver = new AwsEndpointResolver();
+
+  assertEquals(resolver.resolveUrl({
+    requestPath: '/path',
+    region: 'us-east-2',
+    apiMetadata: apiMetadata.ec2,
+  }).url.toString(), 'https://api.ec2.us-east-2.aws/path');
+
+  assertEquals(resolver.resolveUrl({
+    requestPath: '/path',
+    region: 'na-none-1',
+    apiMetadata: apiMetadata.ec2,
+  }).url.toString(), 'https://ec2.na-none-1.amazonaws.com/path');
+});
+
+Deno.test('aws ec2 / allow disabling dualstack', async () => {
+  const resolver = new AwsEndpointResolver({
+    useDualstack: false,
+  });
+
+  assertEquals(resolver.resolveUrl({
+    requestPath: '/path',
+    region: 'us-east-2',
+    apiMetadata: apiMetadata.ec2,
+  }).url.toString(), 'https://ec2.us-east-2.amazonaws.com/path');
+});
+
+Deno.test('aws s3 / upgrades to host style routing', async () => {
+  const resolver = new AwsEndpointResolver();
+
+  assertEquals(resolver.resolveUrl({
+    requestPath: '/bucket/key',
+    region: 'us-east-2',
+    apiMetadata: apiMetadata.s3,
+  }).url.toString(), 'https://bucket.s3.dualstack.us-east-2.amazonaws.com/key');
+
+  assertEquals(resolver.resolveUrl({
+    requestPath: '/bucket/key',
+    region: 'region',
+    apiMetadata: apiMetadata.s3,
+  }).url.toString(), 'https://bucket.s3.dualstack.region.amazonaws.com/key');
+
+  assertEquals(resolver.resolveUrl({
+    requestPath: '/bucket',
+    region: 'region',
+    apiMetadata: apiMetadata.s3,
+  }).url.toString(), 'https://bucket.s3.dualstack.region.amazonaws.com/');
+
+  assertEquals(resolver.resolveUrl({
+    requestPath: '/',
+    region: 'region',
+    apiMetadata: apiMetadata.s3,
+  }).url.toString(), 'https://s3.dualstack.region.amazonaws.com/');
+
+  assertEquals(resolver.resolveUrl({
+    requestPath: '/?query',
+    region: 'region',
+    apiMetadata: apiMetadata.s3,
+  }).url.toString(), 'https://s3.dualstack.region.amazonaws.com/?query');
+});
+
+Deno.test('aws s3 / does not upgrade buckets with dots', async () => {
+  const resolver = new AwsEndpointResolver();
+
+  assertEquals(resolver.resolveUrl({
+    requestPath: '/dotted.bucket/key',
+    region: 'us-east-2',
+    apiMetadata: apiMetadata.s3,
+  }).url.toString(), 'https://s3.dualstack.us-east-2.amazonaws.com/dotted.bucket/key');
+});
+
+Deno.test('aws sts / uses global endpoint by default', async () => {
+  const resolver = new AwsEndpointResolver();
+
+  const endpoint = resolver.resolveUrl({
+    requestPath: '/path',
+    region: 'eu-west-1',
+    apiMetadata: apiMetadata.sts,
+  });
+
+  assertEquals(endpoint.url.toString(), 'https://sts.amazonaws.com/path');
+  assertEquals(endpoint.signingRegion, 'us-east-1');
+});
+
+Deno.test('aws sts / can use regional endpoint by request', async () => {
+  const resolver = new AwsEndpointResolver({
+    forceRegional: true,
+  });
+
+  const endpoint = resolver.resolveUrl({
+    requestPath: '/path',
+    region: 'eu-west-1',
+    apiMetadata: apiMetadata.sts,
+  });
+
+  assertEquals(endpoint.url.toString(), 'https://sts.eu-west-1.amazonaws.com/path');
+  assertEquals(endpoint.signingRegion, 'eu-west-1');
+});
+
+
+const apiMetadata: Record<string, ApiMetadata> = {
+  ec2: {
+    "apiVersion": "2016-11-15",
+    "endpointPrefix": "ec2",
+    "protocol": "ec2",
+    "serviceAbbreviation": "Amazon EC2",
+    "serviceFullName": "Amazon Elastic Compute Cloud",
+    "serviceId": "EC2",
+    "signatureVersion": "v4",
+  },
+  s3: {
+    "apiVersion": "2006-03-01",
+    "endpointPrefix": "s3",
+    "protocol": "rest-xml",
+    "serviceAbbreviation": "Amazon S3",
+    "serviceFullName": "Amazon Simple Storage Service",
+    "serviceId": "S3",
+    "signatureVersion": "s3",
+  },
+  sts: {
+    "apiVersion": "2011-06-15",
+    "endpointPrefix": "sts",
+    "globalEndpoint": "sts.amazonaws.com",
+    "protocol": "query",
+    "serviceAbbreviation": "AWS STS",
+    "serviceFullName": "AWS Security Token Service",
+    "serviceId": "STS",
+    "signatureVersion": "v4",
+  },
+};
+
+
+
+Deno.test('s3 compat / basic assembly', async () => {
+  const resolver = new S3CompatibleEndpointResolver('vendor.tld');
+
+  assertEquals(resolver.resolveUrl({
+    requestPath: '/',
+    region: 'us-east-2',
+    apiMetadata: apiMetadata.s3,
+  }).url.toString(), 'https://us-east-2.vendor.tld/');
+});
+
+Deno.test('s3 compat / virtual host upgrade', async () => {
+  const resolver = new S3CompatibleEndpointResolver('vendor.tld');
+
+  assertEquals(resolver.resolveUrl({
+    requestPath: '/bucket/key',
+    region: 'us-east-2',
+    apiMetadata: apiMetadata.s3,
+  }).url.toString(), 'https://bucket.us-east-2.vendor.tld/key');
+
+  assertEquals(resolver.resolveUrl({
+    requestPath: '/dotted.bucket/key',
+    region: 'us-east-2',
+    apiMetadata: apiMetadata.s3,
+  }).url.toString(), 'https://us-east-2.vendor.tld/dotted.bucket/key');
+});
+
+Deno.test('s3 compat / validation', async () => {
+  assertThrows(() => {
+    new S3CompatibleEndpointResolver('http://localhost');
+  }, Error, 'must be a naked domain name');
+});
+
+Deno.test('s3 compat / refuse non-S3', async () => {
+  const resolver = new S3CompatibleEndpointResolver('vendor.tld');
+
+  assertThrows(() => {
+    resolver.resolveUrl({
+      requestPath: '/path',
+      region: 'region',
+      apiMetadata: apiMetadata.ec2,
+    })
+  }, Error, 'only implements S3 requests');
+});
+
+
+
+Deno.test('fixed base / basic assembly', async () => {
+  const resolver = new FixedBaseEndpointResolver('http://localhost:9000');
+
+  assertEquals(resolver.resolveUrl({
+    requestPath: '/path',
+    region: 'us-east-2',
+    apiMetadata: apiMetadata.s3,
+  }).url.toString(), 'http://localhost:9000/path');
+});
+
+Deno.test('fixed base / validation', async () => {
+  assertThrows(() => {
+    new FixedBaseEndpointResolver('localhost');
+  }, Error, 'must be a full URL');
+});

--- a/lib/client/mod.ts
+++ b/lib/client/mod.ts
@@ -8,10 +8,32 @@ export type {
   Credentials, CredentialsProvider,
 } from './common.ts';
 
+export {
+  AwsEndpointResolver,
+  S3CompatibleEndpointResolver,
+  FixedBaseEndpointResolver,
+} from "./endpoints.ts";
+
+export {
+  DefaultCredentialsProvider,
+  CredentialsProviderChain,
+  EC2MetadataCredentials,
+  EnvironmentCredentials,
+  SharedIniFileCredentials,
+  TokenFileWebIdentityCredentials,
+} from "./credentials.ts";
+
+// ---
+
 import {
   Credentials, CredentialsProvider,
   DefaultCredentialsProvider,
 } from "./credentials.ts";
+import {
+  EndpointResolver,
+  AwsEndpointResolver,
+  FixedBaseEndpointResolver,
+} from "./endpoints.ts";
 import {
   BaseApiFactory,
 } from "./client.ts";
@@ -22,9 +44,13 @@ export class ApiFactory extends BaseApiFactory {
     credentials?: Credentials,
     region?: string;
     fixedEndpoint?: string;
+    endpointResolver?: EndpointResolver,
   }={}) {
     super({
       credentialProvider: DefaultCredentialsProvider,
+      endpointResolver: (typeof opts.fixedEndpoint == 'string')
+        ? new FixedBaseEndpointResolver(opts.fixedEndpoint)
+        : new AwsEndpointResolver(),
       ...opts,
     });
   }

--- a/lib/client/signing.ts
+++ b/lib/client/signing.ts
@@ -99,15 +99,14 @@ export class AWSSignerV4 implements Signer {
    */
   public async sign(
     service: string,
-    url: string,
+    url: URL,
     request: Request,
   ): Promise<Request> {
     const date = new Date();
     const amzdate = toAmz(date);
     const datestamp = toDateStamp(date);
 
-    const urlObj = new URL(url);
-    const { host, pathname, searchParams } = urlObj;
+    const { host, pathname, searchParams } = url;
     searchParams.sort();
     const canonicalQuerystring = searchParams.toString();
 
@@ -159,7 +158,7 @@ export class AWSSignerV4 implements Signer {
     headers.set("Authorization", authHeader);
 
     return new Request(
-      url,
+      url.toString(),
       {
         headers,
         method: request.method,


### PR DESCRIPTION
* Seperate URL building out into a clean new tested module
* Allow for swapping out the URL-building logic entirely
* Better configurability for dual-stack such as opt-out
* Allow forcing regional endpoints for local STS
* Continue supporting basic fixedEndpoint usage

A better fix for #3 / #7