### PR TITLE
Add Deno platform cache to codegen service

### DIFF
--- a/generation/deploy/cache-platform.ts
+++ b/generation/deploy/cache-platform.ts
@@ -4,7 +4,7 @@ import { trace } from "./tracer.ts";
 // https://docs.deno.com/deploy/manual/edge-cache
 
 function transformUrl(url: string) {
-  return url.replace(/\/\/[^\/]+\//, '//upstream-cache-v1/');
+  return url.replace(/\/\/[^\/]+\//, '//upstream-cache-v2/');
 }
 
 export async function platformCache(
@@ -27,7 +27,7 @@ export async function platformCache(
       type CachePolicy = Parameters<ConstructorParameters<typeof Cache>[0]['set']>[1]['policy'];
 
       const {
-        'cache-policy': policyHeader,
+        'x-cache-policy': policyHeader,
         ...resh
       } = Object.fromEntries(cached.headers.entries());
 
@@ -56,7 +56,7 @@ export async function platformCache(
       await nativeCache.put(transformUrl(url), new Response(resp.body, {
         headers: {
           ...resh,
-          'cache-policy': JSON.stringify(rest),
+          'x-cache-policy': JSON.stringify(rest),
         },
       }));
     },

--- a/generation/deploy/cache-platform.ts
+++ b/generation/deploy/cache-platform.ts
@@ -32,6 +32,9 @@ export async function platformCache(
       } = Object.fromEntries(cached.headers.entries());
 
       if (!policyHeader) {
+        trace.getActiveSpan()?.addEvent('edgecache.fail', {
+          'message': 'platform cache hit lacked policy',
+        });
         console.warn('WARN: platform cache lacked policy', cached);
         return undefined;
       }

--- a/generation/deploy/cache-platform.ts
+++ b/generation/deploy/cache-platform.ts
@@ -3,6 +3,10 @@ import { trace } from "./tracer.ts";
 
 // https://docs.deno.com/deploy/manual/edge-cache
 
+function transformUrl(url: string) {
+  return url.replace(/\/\/[^\/]+\//, '//upstream-cache-v1/');
+}
+
 export async function platformCache(
   name = 'http-policy-cache',
 ): Promise<Cache> {
@@ -12,7 +16,7 @@ export async function platformCache(
   return new Cache({
 
     async get(url) {
-      const cached = await nativeCache.match(url);
+      const cached = await nativeCache.match(transformUrl(url));
 
       trace.getActiveSpan()?.addEvent('edgecache', {
         'cache.result': cached ? 'hit' : 'miss',
@@ -46,7 +50,7 @@ export async function platformCache(
 
     async set(url, resp) {
       const {resh, ...rest} = resp.policy;
-      await nativeCache.put(url, new Response(resp.body, {
+      await nativeCache.put(transformUrl(url), new Response(resp.body, {
         headers: {
           ...resh,
           'cache-policy': JSON.stringify(rest),
@@ -55,7 +59,7 @@ export async function platformCache(
     },
 
     async delete(url) {
-      await nativeCache.delete(url);
+      await nativeCache.delete(transformUrl(url));
     },
 
     close() {},

--- a/generation/deploy/cache-platform.ts
+++ b/generation/deploy/cache-platform.ts
@@ -1,4 +1,5 @@
 import { Cache } from "https://deno.land/x/httpcache@0.1.2/mod.ts";
+import { trace } from "./tracer.ts";
 
 // https://docs.deno.com/deploy/manual/edge-cache
 
@@ -12,6 +13,11 @@ export async function platformCache(
 
     async get(url) {
       const cached = await nativeCache.match(url);
+
+      trace.getActiveSpan()?.addEvent('edgecache', {
+        'cache.result': cached ? 'hit' : 'miss',
+      });
+
       if (!cached) return undefined;
 
       type CachePolicy = Parameters<ConstructorParameters<typeof Cache>[0]['set']>[1]['policy'];

--- a/generation/deploy/cache-platform.ts
+++ b/generation/deploy/cache-platform.ts
@@ -17,11 +17,6 @@ export async function platformCache(
 
     async get(url) {
       const cached = await nativeCache.match(transformUrl(url));
-
-      trace.getActiveSpan()?.addEvent('edgecache', {
-        'cache.result': cached ? 'hit' : 'miss',
-      });
-
       if (!cached) return undefined;
 
       type CachePolicy = Parameters<ConstructorParameters<typeof Cache>[0]['set']>[1]['policy'];

--- a/generation/deploy/cache-platform.ts
+++ b/generation/deploy/cache-platform.ts
@@ -14,17 +14,26 @@ export async function platformCache(
       const cached = await nativeCache.match(url);
       if (!cached) return undefined;
 
-      const {'cache-policy': policyHeader, ...rest} = Object.fromEntries(cached.headers.entries());
+      type CachePolicy = Parameters<ConstructorParameters<typeof Cache>[0]['set']>[1]['policy'];
+
+      const {
+        'cache-policy': policyHeader,
+        ...resh
+      } = Object.fromEntries(cached.headers.entries());
+
       if (!policyHeader) {
         console.warn('WARN: platform cache lacked policy', cached);
         return undefined;
       }
-      rest['resh'] = JSON.parse(policyHeader);
+      const policy = {
+        ...JSON.parse(policyHeader),
+        resh,
+      } as CachePolicy;
 
       const BodyBuffer = new Uint8Array(await cached.arrayBuffer());
 
       return {
-        policy: rest,
+        policy,
         body: BodyBuffer,
       };
     },

--- a/generation/deploy/cache-platform.ts
+++ b/generation/deploy/cache-platform.ts
@@ -6,7 +6,7 @@ export async function platformCache(
   name = 'http-policy-cache',
 ): Promise<Cache> {
 
-  const nativeCache = await globalThis.caches.open(name);
+  const nativeCache = await caches.open(name);
 
   return new Cache({
 

--- a/generation/deploy/cache-platform.ts
+++ b/generation/deploy/cache-platform.ts
@@ -1,0 +1,48 @@
+import { Cache } from "https://deno.land/x/httpcache@0.1.2/mod.ts";
+
+// https://docs.deno.com/deploy/manual/edge-cache
+
+export async function platformCache(
+  name = 'http-policy-cache',
+): Promise<Cache> {
+
+  const nativeCache = await globalThis.caches.open(name);
+
+  return new Cache({
+
+    async get(url) {
+      const cached = await nativeCache.match(url);
+      if (!cached) return undefined;
+
+      const policyHeader = cached.headers.get('cache-policy');
+      if (!policyHeader) {
+        console.warn('WARN: platform cache lacked policy', cached);
+        return undefined;
+      }
+
+      const BodyBuffer = new Uint8Array(await cached.arrayBuffer());
+
+      // const idx = BodyBuffer.indexOf(10);
+      return {
+        // policy: JSON.parse(new TextDecoder().decode(BodyBuffer.slice(0, idx))),
+        policy: JSON.parse(policyHeader),
+        // body: BodyBuffer.slice(idx+1),
+        body: BodyBuffer,
+      };
+    },
+
+    async set(url, resp) {
+      await nativeCache.put(url, new Response(resp.body, {
+        headers: {
+          'cache-policy': JSON.stringify(resp.policy),
+        },
+      }));
+    },
+
+    async delete(url) {
+      await nativeCache.delete(url);
+    },
+
+    close() {},
+  });
+}

--- a/generation/deploy/cache-platform.ts
+++ b/generation/deploy/cache-platform.ts
@@ -14,27 +14,27 @@ export async function platformCache(
       const cached = await nativeCache.match(url);
       if (!cached) return undefined;
 
-      const policyHeader = cached.headers.get('cache-policy');
+      const {'cache-policy': policyHeader, ...rest} = Object.fromEntries(cached.headers.entries());
       if (!policyHeader) {
         console.warn('WARN: platform cache lacked policy', cached);
         return undefined;
       }
+      rest['resh'] = JSON.parse(policyHeader);
 
       const BodyBuffer = new Uint8Array(await cached.arrayBuffer());
 
-      // const idx = BodyBuffer.indexOf(10);
       return {
-        // policy: JSON.parse(new TextDecoder().decode(BodyBuffer.slice(0, idx))),
-        policy: JSON.parse(policyHeader),
-        // body: BodyBuffer.slice(idx+1),
+        policy: rest,
         body: BodyBuffer,
       };
     },
 
     async set(url, resp) {
+      const {resh, ...rest} = resp.policy;
       await nativeCache.put(url, new Response(resp.body, {
         headers: {
-          'cache-policy': JSON.stringify(resp.policy),
+          ...resh,
+          'cache-policy': JSON.stringify(rest),
         },
       }));
     },


### PR DESCRIPTION
Uses a beta feature documented here: https://docs.deno.com/deploy/manual/edge-cache

Once this feature stabilizes, I think we can replace the whole tiered cache system / library with the platform native cache.